### PR TITLE
ofpathname: map mpath* devices to the appropriate dm-* generic dm device

### DIFF
--- a/scripts/ofpathname
+++ b/scripts/ofpathname
@@ -472,6 +472,10 @@ logical_to_ofpathname()
         hd*)        l2of_ide ;;
 	vd*)	    l2of_vd ;;
         fd*)        echo "no fd support yet" ;;
+        mpath*)
+                    DEVNAME=$(printf "dm-%d" `stat -c "%T" /dev/mapper/$DEVICE`)
+                    logical_to_ofpathname
+                    ;;
         dm-*)
                     DEVNAME=`get_slave $DEVICE`
                     logical_to_ofpathname


### PR DESCRIPTION

Signed-off-by: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>