### PR TITLE
ofpathname: add support for NVMe logical/OpenFirmware device path conversion

### DIFF
--- a/scripts/ofpathname
+++ b/scripts/ofpathname
@@ -998,6 +998,10 @@ ofpathname_to_logical()
         fi
     fi
 
+    if [[ $DEVTYPE = "namespace" ]]; then
+        DEVTYPE="nvme"
+    fi
+
     # Remove any possible cdrom data from DEVICE
     if [[ ${DEVICE##*,} = "\ppc\bootinfo.txt" ||
           ${DEVICE##*,} = \ppc\bootinfo.txt ]]; then
@@ -1022,6 +1026,7 @@ ofpathname_to_logical()
         hfi-ethernet* )  of2l_hfi ;;
         disk*         )  of2l_ide ;;
         usb           )  of2l_usb ;;
+        nvme          )  of2l_nvme ;;
     esac
 
     if [[ -z $LOGICAL_DEVNAME ]]; then
@@ -1551,6 +1556,64 @@ of2l_fc()
                 fi
         fi
     done
+}
+
+#
+# of2l_nvme
+# Conversion routine for OF path => logical name for nvme devices
+#
+of2l_nvme()
+{
+    # get namespace id and partition number
+    local nsid_part=${DEVICE##*@} # <namespace-id>[:partition-number]
+    local nsid=${nsid_part%:*} # namespace id
+    local part # partition number
+
+    # set partition number only if ':' is present
+    case "${nsid_part}" in
+    *:*)
+        part=${nsid_part#*:}
+        ;;
+    esac
+
+    local dir
+    local link
+
+    for dir in `$FIND /sys/block -name "nvme*n$nsid"`; do
+        cd $dir
+
+        link=`get_link "device"` # points to nvme[0-9]+ (non-namespace)
+        if [[ -n $link ]]; then
+            cd $link
+        else
+            continue
+        fi
+
+        link=`get_link "device"` # points to pci address dir
+        if [[ -n $link ]]; then
+            cd $link
+        else
+            continue
+        fi
+
+        goto_dir $PWD "devspec"
+        local devspec=`$CAT ./devspec 2>/dev/null`
+
+        if [[ $devspec = $DEVPATH ]]; then
+            LOGICAL_DEVNAME="${dir##*/}"
+            break
+        fi
+    done
+
+    if [[ -n $LOGICAL_DEVNAME ]] \
+    && [[ -n $part ]]; then
+
+        if [[ -d "/sys/block/${LOGICAL_DEVNAME}/${LOGICAL_DEVNAME}p${part}" ]]; then
+            LOGICAL_DEVNAME="${LOGICAL_DEVNAME}p${part}"
+        else
+            LOGICAL_DEVNAME=''
+        fi
+    fi
 }
 
 #

--- a/scripts/ofpathname
+++ b/scripts/ofpathname
@@ -477,6 +477,7 @@ logical_to_ofpathname()
                     logical_to_ofpathname
                     exit
                     ;;
+	nvme*)	    l2of_nvme ;;
 	*)         # check if the device is a network interface
                    is_net=$(is_net_interface $DEVICE)
                    if [[ $is_net = "yes" ]]; then
@@ -613,6 +614,78 @@ l2of_hfi()
     fi
 
     OF_PATH=${hfpath##/proc/device-tree}
+}
+
+#
+# l2of_nvme
+# Conversion routine for logical => OF path of nvme devices
+#
+l2of_nvme()
+{
+    # OF path: <devspec>/namespace@<namespace-id>:<partition-number>
+
+    # disk: nvmeX, nvmeXnY; not nvmeXnYpZ
+    local devdisk="${DEVICE%p[0-9]*}"
+
+    # namespace id: Y in nvmeXnY, nvmeXnYpZ
+    local devnsid="${devdisk#nvme[0-9]*n}"
+    if [[ $devnsid = $devdisk ]]; then
+        devnsid='' # no namespace id
+    fi
+
+    # partition number: Z in nvmeXnYpZ
+    local devpart="${DEVICE##*p}"
+    if [[ $devpart = $DEVICE ]]; then
+        devpart='' # no partition number
+    fi
+
+    # Get the device-tree device specification (devspec).
+    local dir
+    local found=0
+
+    for dir in `$FIND /sys/devices -name "$DEVICE"`; do
+        cd $dir
+
+        goto_dir $PWD "device/devspec"
+
+        devspec=`$CAT $PWD/device/devspec`
+        if [[ -n $devspec ]]; then
+            found=1
+            break
+        fi
+    done
+
+    if [[ $found -eq 0 ]]; then
+        err $ERR_NO_SYSFS_DEVINFO
+    fi
+
+    if [[ -z $devspec ]]; then
+        err $ERR_NO_OFPATH
+    fi
+
+    # OF path: <devspec>/namespace@<namespace-id>:<partition-number>
+    OF_PATH="$devspec"
+
+    # No namespace id (nY) specified.
+    if [[ -z $devnsid ]]; then
+        return
+    fi
+
+    # Device type is usually 'namespace'.
+    # Get it from device-tree just in case.
+    devtype=`$CAT /proc/device-tree${devspec}/namespace/name`
+    if [[ -z $devtype ]]; then
+        err $ERR_NO_OFPATH
+    fi
+
+    OF_PATH="$OF_PATH/$devtype@$devnsid"
+
+    # No partition (pZ) specified.
+    if [[ -z $devpart ]]; then
+        return
+    fi
+
+    OF_PATH="${OF_PATH}:${devpart}"
 }
 
 #


### PR DESCRIPTION
These 2 patches add the functions `of2l_nvme()` and `l2of_nvme()` to `scripts/ofpathname`.

Test scenario:

```
# ls -1d /dev/nvme*
/dev/nvme0
/dev/nvme0n1
/dev/nvme0n1p1
/dev/nvme0n1p2
/dev/nvme0n1p3
```

Test results:


`l2of_nvme()`

Existing devices:

```
# ofpathname /dev/nvme0
/pci@80000002000001c/pci1014,4f5@0

# ofpathname /dev/nvme0n1
/pci@80000002000001c/pci1014,4f5@0/namespace@1

# ofpathname /dev/nvme0n1p1
/pci@80000002000001c/pci1014,4f5@0/namespace@1:1

# ofpathname /dev/nvme0n1p2
/pci@80000002000001c/pci1014,4f5@0/namespace@1:2

# ofpathname /dev/nvme0n1p3
/pci@80000002000001c/pci1014,4f5@0/namespace@1:3
```

Non-existing devices:

```
# ofpathname /dev/nvme1
ofpathname: Could not find sysfs information for logical
            device "/dev/nvme1".

# ofpathname /dev/nvme0n2
ofpathname: Could not find sysfs information for logical
            device "/dev/nvme0n2".

# ofpathname /dev/nvme0n1p0
ofpathname: Could not find sysfs information for logical
            device "/dev/nvme0n1p0".
```

`of2l_nvme()`

Existing devices:

```
# ofpathname -l /pci@80000002000001c/pci1014,4f5@0
ofpathname: Could not retrieve logical device name for
            Open Firmware path "/pci@80000002000001c/pci1014,4f5@0".
```

The case without a namespace ID (above) can not be handled 
as there's not enough information available in the OpenFirmware
device path nor device-tree in order to match it uniquely to a
nvmeX device path.

Anything with a namespace ID (below) has enough information and works:

```
# ofpathname -l /pci@80000002000001c/pci1014,4f5@0/namespace@1
nvme0n1

# ofpathname -l /pci@80000002000001c/pci1014,4f5@0/namespace@1:1
nvme0n1p1

# ofpathname -l /pci@80000002000001c/pci1014,4f5@0/namespace@1:2
nvme0n1p2

# ofpathname -l /pci@80000002000001c/pci1014,4f5@0/namespace@1:3
nvme0n1p3
```

Non-existing devices:

```
# ofpathname -l /pci@80000002000001c/pci1014,4f5@0/namespace@0
ofpathname: Could not retrieve logical device name for
            Open Firmware path "/pci@80000002000001c/pci1014,4f5@0/namespace@0".

# ofpathname -l /pci@80000002000001c/pci1014,4f5@0/namespace@1:0
ofpathname: Could not retrieve logical device name for
            Open Firmware path "/pci@80000002000001c/pci1014,4f5@0/namespace@1:0".
```

Thanks: Colleen Stouffer, for technical advice and hardware availability.
