### PR TITLE
Eliminate some warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
 
     - name: configure
       run: |
-       ./configure --prefix=/usr --host=${{ matrix.host }} --enable-werror --build=x86_64-linux-gnu CFLAGS='-O2 -g'
+       ./configure --prefix=/usr --host=${{ matrix.host }} --enable-werror --build=x86_64-linux-gnu CFLAGS='-O2 -g -Wextra -Wno-error=unused-parameter'
 
     - name: Collect config.log
       if: ${{ failure() }}

--- a/src/drmgr/common.c
+++ b/src/drmgr/common.c
@@ -1270,10 +1270,10 @@ int update_sysparm(void)
 			return 1;
 		}
 
-		usr_drc_count = -usr_drc_count;
+		return set_sysparm(linux_parm, curval - usr_drc_count);
+	} else {
+		return set_sysparm(linux_parm, curval + usr_drc_count);
 	}
-	
-	return set_sysparm(linux_parm, curval + usr_drc_count);
 }
 
 int

--- a/src/drmgr/common.c
+++ b/src/drmgr/common.c
@@ -730,7 +730,7 @@ update_property(const char *buf, size_t len)
  * @returns 0 on success, -1 otherwise
  */
 static int
-get_att_prop(const char *path, const char *name, char *buf, size_t buf_sz,
+get_att_prop(const char *path, const char *name, char *buf, ssize_t buf_sz,
 	     const char *attr_type)
 {
 	FILE *fp;
@@ -797,7 +797,7 @@ get_att_prop(const char *path, const char *name, char *buf, size_t buf_sz,
  * @returns 0 on success, !0 otherwise
  */
 int
-get_property(const char *path, const char *property, void *buf, size_t buf_sz)
+get_property(const char *path, const char *property, void *buf, ssize_t buf_sz)
 {
 	return get_att_prop(path, property, buf, buf_sz, NULL);
 }
@@ -814,7 +814,7 @@ get_property(const char *path, const char *property, void *buf, size_t buf_sz)
  */
 int
 get_int_attribute(const char *path, const char *attribute, void *buf,
-		  size_t buf_sz)
+		  ssize_t buf_sz)
 {
 	return get_att_prop(path, attribute, buf, buf_sz, "%i");
 }
@@ -831,7 +831,7 @@ get_int_attribute(const char *path, const char *attribute, void *buf,
  */
 int
 get_str_attribute(const char *path, const char *attribute, void *buf,
-		  size_t buf_sz)
+		  ssize_t buf_sz)
 {
 	return get_att_prop(path, attribute, buf, buf_sz, "%s");
 }

--- a/src/drmgr/common.c
+++ b/src/drmgr/common.c
@@ -94,7 +94,7 @@ static const char * const hook_action_name[] = {
  * @param level level to set the output level to
  */
 inline void
-set_output_level(int level)
+set_output_level(unsigned level)
 {
 	output_level = level;
 

--- a/src/drmgr/common.c
+++ b/src/drmgr/common.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <signal.h>
+#include <assert.h>
 #include <errno.h>
 #include <dirent.h>
 #ifdef __GLIBC__
@@ -770,7 +771,10 @@ get_att_prop(const char *path, const char *name, char *buf, ssize_t buf_sz,
 		break;
 
 	    case 's':	/* sysfs */
-		rc = fscanf(fp, attr_type, (int *)buf);
+		if (attr_type)
+			rc = fscanf(fp, attr_type, (int *)buf);
+		else
+			rc = -1;	/* glibc behavior but not guaranteed by POSIX */
 		break;
 	}
 

--- a/src/drmgr/common_numa.c
+++ b/src/drmgr/common_numa.c
@@ -27,7 +27,7 @@
 #include "drmem.h"		/* for DYNAMIC_RECONFIG_MEM */
 #include "common_numa.h"
 
-struct ppcnuma_node *ppcnuma_fetch_node(struct ppcnuma_topology *numa, int nid)
+struct ppcnuma_node *ppcnuma_fetch_node(struct ppcnuma_topology *numa, unsigned nid)
 {
 	struct ppcnuma_node *node;
 
@@ -67,7 +67,8 @@ static int read_numa_topology(struct ppcnuma_topology *numa)
 {
 	struct bitmask *cpus;
 	struct ppcnuma_node *node;
-	int rc, max_node, nid, i;
+	int rc;
+	unsigned max_node, nid, i;
 
 	if (numa_available() < 0)
 		return -ENOENT;

--- a/src/drmgr/common_numa.h
+++ b/src/drmgr/common_numa.h
@@ -46,10 +46,10 @@ struct ppcnuma_topology {
 
 int ppcnuma_get_topology(struct ppcnuma_topology *numa);
 struct ppcnuma_node *ppcnuma_fetch_node(struct ppcnuma_topology *numa,
-					int node_id);
+					unsigned node_id);
 
-static inline int ppcnuma_next_node(struct ppcnuma_topology *numa, int nid,
-				    struct ppcnuma_node **node)
+static inline unsigned ppcnuma_next_node(struct ppcnuma_topology *numa, unsigned nid,
+				         struct ppcnuma_node **node)
 {
 	for (nid++; nid <= numa->node_max; nid++)
 		if (numa->nodes[nid]) {

--- a/src/drmgr/common_ofdt.c
+++ b/src/drmgr/common_ofdt.c
@@ -844,7 +844,7 @@ int get_min_common_depth(void)
 	size = load_property(RTAS_DIRECTORY, ASSOC_REF_POINTS, &p);
 	if (size <= 0)
 		return size;
-	if (size < sizeof(uint32_t)) {
+	if (size < (int)sizeof(uint32_t)) {
 		report_unknown_error(__FILE__, __LINE__);
 		free(p);
 		return -EINVAL;
@@ -884,7 +884,7 @@ int get_assoc_arrays(const char *dir, struct assoc_arrays *aa,
 	}
 
 	/* Sanity check */
-	if (size != (aa->n_arrays * aa->array_sz + 2)) {
+	if ((unsigned)size != (aa->n_arrays * aa->array_sz + 2)) {
 		say(ERROR, "Bad size of the associativity lookup arrays\n");
 		goto out_free;
 	}

--- a/src/drmgr/common_ofdt.c
+++ b/src/drmgr/common_ofdt.c
@@ -857,7 +857,7 @@ int get_min_common_depth(void)
 }
 
 int get_assoc_arrays(const char *dir, struct assoc_arrays *aa,
-		     int min_common_depth)
+		     unsigned min_common_depth)
 {
 	int size;
 	int rc;
@@ -908,7 +908,7 @@ out_free:
  * Read the associativity property and return the node id matching the
  * min_common_depth entry.
  */
-int of_associativity_to_node(const char *dir, int min_common_depth)
+int of_associativity_to_node(const char *dir, unsigned min_common_depth)
 {
 	int size;
 	uint32_t *prop;

--- a/src/drmgr/common_pci.c
+++ b/src/drmgr/common_pci.c
@@ -1050,7 +1050,7 @@ get_bus_id(char *loc_code)
 	DIR *d;
 	struct dirent *ent;
 	char *dir = "/sys/bus/pci/slots";
-	int inlen;
+	size_t inlen;
 	char *ptr;
 
 	/* Strip any newline from the input location */

--- a/src/drmgr/dr.h
+++ b/src/drmgr/dr.h
@@ -79,7 +79,7 @@ extern int usr_timeout;
 extern char *usr_drc_name;
 extern uint32_t usr_drc_index;
 extern int usr_prompt;
-extern int usr_drc_count;
+extern unsigned usr_drc_count;
 extern enum drc_type usr_drc_type;
 extern char *usr_p_option;
 extern char *usr_t_option;

--- a/src/drmgr/dr.h
+++ b/src/drmgr/dr.h
@@ -30,7 +30,7 @@
 #include "rtas_calls.h"
 #include "drpci.h"
 
-extern int output_level;
+extern unsigned output_level;
 extern int log_fd;
 
 extern int read_dynamic_memory_v2;
@@ -133,7 +133,7 @@ int cpu_entitlement_capable(void);
 int mem_entitlement_capable(void);
 void print_dlpar_capabilities(void);
 
-void set_output_level(int);
+void set_output_level(unsigned);
 
 int run_hooks(enum drc_type drc_type, enum drmgr_action, enum hook_phase phase,
 	      int drc_count);

--- a/src/drmgr/dr.h
+++ b/src/drmgr/dr.h
@@ -110,9 +110,9 @@ int add_device_tree_nodes(char *, struct of_node *);
 int remove_device_tree_nodes(const char *path);
 
 int update_property(const char *, size_t);
-int get_property(const char *, const char *, void *, size_t);
-int get_int_attribute(const char *, const char *, void *, size_t);
-int get_str_attribute(const char *, const char *, void *, size_t);
+int get_property(const char *, const char *, void *, ssize_t);
+int get_int_attribute(const char *, const char *, void *, ssize_t);
+int get_str_attribute(const char *, const char *, void *, ssize_t);
 int get_ofdt_uint_property(const char *, const char *, uint *);
 int get_property_size(const char *, const char *);
 int signal_handler(int, int, struct sigcontext *);

--- a/src/drmgr/dracc_chrp_acc.c
+++ b/src/drmgr/dracc_chrp_acc.c
@@ -79,11 +79,6 @@ int dracc_chrp_acc(void)
 		return -1;
 	}
 
-	if (usr_drc_count < 0) {
-		say(ERROR, "Invalid QoS credit count %d\n", usr_drc_count);
-		return -1;
-	}
-
 	fd = open(SYSFS_VAS_QOSCREDIT_FILE, O_WRONLY);
 	if (fd < 0) {
 		say(ERROR, "Could not open \"%s\" to write QoS credits\n",

--- a/src/drmgr/drmem.h
+++ b/src/drmgr/drmem.h
@@ -24,7 +24,7 @@ struct lmb_list_head {
 	struct dr_node	*last;
 	char		*drconf_buf;
 	int		drconf_buf_sz;
-	int		lmbs_modified;
+	unsigned	lmbs_modified;
 	int		sort;
 	int		lmbs_found;
 };

--- a/src/drmgr/drmgr.c
+++ b/src/drmgr/drmgr.c
@@ -32,7 +32,7 @@
 
 #define DRMGR_ARGS	"ac:d:Iimnp:P:Qq:Rrs:w:t:hCVH"
 
-int output_level = 1; /* default to lowest output level */
+unsigned output_level = 1; /* default to lowest output level */
 
 int log_fd = 0;
 int action_cnt = 0;
@@ -202,7 +202,7 @@ int parse_options(int argc, char *argv[])
 			display_capabilities = 1;
 			break;
 		    case 'd':
-			set_output_level(atoi(optarg));
+			set_output_level(strtoul(optarg, NULL, 10));
 			break;
 		    case 'I':
 			usr_slot_identification = 0;

--- a/src/drmgr/drslot_chrp_cpu.c
+++ b/src/drmgr/drslot_chrp_cpu.c
@@ -231,7 +231,7 @@ struct dr_node *get_available_cpu(struct dr_info *dr_info)
  * @param nr_cpus
  * @returns 0 on success, !0 otherwise
  */
-static int add_cpus(struct dr_info *dr_info, int *count)
+static int add_cpus(struct dr_info *dr_info, unsigned *count)
 {
 	int rc = -1;
 	struct dr_node *cpu = NULL;
@@ -285,7 +285,7 @@ static int add_cpus(struct dr_info *dr_info, int *count)
  * @param nr_cpus
  * @returns 0 on success, !0 otherwise
  */
-static int remove_cpus(struct dr_info *dr_info, int *count)
+static int remove_cpus(struct dr_info *dr_info, unsigned *count)
 {
 	int rc = 0;
 	struct dr_node *cpu;
@@ -405,7 +405,8 @@ int valid_cpu_options(void)
 int drslot_chrp_cpu(void)
 {
 	struct dr_info dr_info;
-	int rc, count = 0;
+	int rc;
+	unsigned count = 0;
 
 	if (! cpu_dlpar_capable()) {
 		say(ERROR, "CPU DLPAR capability is not enabled on this "

--- a/src/drmgr/drslot_chrp_mem.c
+++ b/src/drmgr/drslot_chrp_mem.c
@@ -1473,7 +1473,8 @@ static int remove_lmb_by_index(uint32_t drc_index)
 static int remove_lmb_from_node(struct ppcnuma_node *node, uint32_t count)
 {
 	struct dr_node *lmb;
-	int err, done = 0, unlinked = 0;
+	int err;
+	unsigned done = 0, unlinked = 0;
 
 	say(DEBUG, "Try removing %d / %d LMBs from node %d\n",
 	    count, node->n_lmbs, node->node_id);

--- a/src/drmgr/drslot_chrp_mem.c
+++ b/src/drmgr/drslot_chrp_mem.c
@@ -312,12 +312,14 @@ get_mem_node_lmbs(struct lmb_list_head *lmb_list)
 
 static int link_lmb_to_numa_node(struct dr_node *lmb)
 {
-	int nid;
+	int ret;
+	unsigned nid;
 	struct ppcnuma_node *node;
 
-	nid = aa_index_to_node(&numa.aa, lmb->lmb_aa_index);
-	if (nid == -1)
+	ret = aa_index_to_node(&numa.aa, lmb->lmb_aa_index);
+	if (ret == -1)
 		return 0;
+	nid = ret;
 
 	node = ppcnuma_fetch_node(&numa, nid);
 	if (!node)
@@ -1521,7 +1523,7 @@ static int remove_lmb_from_node(struct ppcnuma_node *node, uint32_t count)
 static void update_cpuless_node_ratio(void)
 {
 	struct ppcnuma_node *node;
-	int nid;
+	unsigned nid;
 
 	/*
 	 * Assumptions:
@@ -1549,7 +1551,7 @@ static void update_cpuless_node_ratio(void)
 static int remove_cpuless_lmbs(uint32_t count)
 {
 	struct ppcnuma_node *node;
-	int nid;
+	unsigned nid;
 	uint32_t total = count, todo, done = 0, this_loop;
 
 	while (count) {
@@ -1593,7 +1595,7 @@ static int remove_cpuless_lmbs(uint32_t count)
 
 static void update_node_ratio(void)
 {
-	int nid;
+	unsigned nid;
 	struct ppcnuma_node *node, *n, **p;
 	uint32_t cpu_ratio, mem_ratio;
 
@@ -1695,7 +1697,7 @@ static void build_numa_topology(void)
 
 static void clear_numa_lmb_links(void)
 {
-	int nid;
+	unsigned nid;
 	struct ppcnuma_node *node;
 
 	ppcnuma_foreach_node(&numa, nid, node)
@@ -1706,7 +1708,7 @@ static int numa_based_remove(uint32_t count)
 {
 	struct lmb_list_head *lmb_list;
 	struct ppcnuma_node *node;
-	int nid;
+	unsigned nid;
 	uint32_t done = 0;
 
 	/*

--- a/src/drmgr/drslot_chrp_mem.c
+++ b/src/drmgr/drslot_chrp_mem.c
@@ -441,7 +441,8 @@ int get_dynamic_reconfig_lmbs_v2(uint64_t lmb_sz,
 {
 	struct drconf_mem_v2 *drmem;
 	uint32_t lmb_sets;
-	int i, rc = 0;
+	unsigned i;
+	int rc;
 
 	lmb_list->drconf_buf_sz = get_property_size(DYNAMIC_RECONFIG_MEM,
 						   "ibm,dynamic-memory-v2");
@@ -471,7 +472,7 @@ int get_dynamic_reconfig_lmbs_v2(uint64_t lmb_sz,
 	for (i = 0; i < lmb_sets; i++) {
 		uint32_t drc_index, seq_lmbs;
 		uint64_t address;
-		int j;
+		unsigned j;
 
 		address = be64toh(drmem->base_addr);
 		drc_index = be32toh(drmem->drc_index);
@@ -741,7 +742,7 @@ static void update_drconf_affinity(struct dr_node *lmb,
 	uint32_t assoc_entries;
 	uint32_t assoc_entry_sz;
 	uint32_t *prop_val;
-	int i;
+	unsigned i;
 
 	/* find the ibm,associativity property */
 	node = lmb->lmb_of_node;

--- a/src/drmgr/lparnumascore.c
+++ b/src/drmgr/lparnumascore.c
@@ -39,7 +39,7 @@
 
 #define NUMA_NO_NODE	-1
 
-int output_level = 0;
+unsigned output_level = 0;
 int log_fd = 0;
 int min_common_depth;
 int read_dynamic_memory_v2 = 1;
@@ -249,7 +249,7 @@ static int parse_options(int argc, char *argv[])
 			}
 			break;
 		case 'd':
-			set_output_level(atoi(optarg));
+			set_output_level(strtoul(optarg, NULL, 10));
 			break;
 		case 'h':
 			usage();

--- a/src/drmgr/lparnumascore.c
+++ b/src/drmgr/lparnumascore.c
@@ -41,7 +41,7 @@
 
 unsigned output_level = 0;
 int log_fd = 0;
-int min_common_depth;
+unsigned min_common_depth;
 int read_dynamic_memory_v2 = 1;
 
 static bool check_node(char *syspath, int node)
@@ -276,6 +276,8 @@ static int parse_options(int argc, char *argv[])
 
 int main(int argc, char *argv[])
 {
+	int rc;
+
 	if (parse_options(argc, argv))
 		exit(1);
 
@@ -290,9 +292,10 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	min_common_depth = get_min_common_depth();
-	if (min_common_depth < 0)
+	rc = get_min_common_depth();
+	if (rc < 0)
 		exit(1);
+	min_common_depth = rc;
 
 	switch (usr_drc_type) {
 	case DRC_TYPE_CPU:

--- a/src/drmgr/lsslot.c
+++ b/src/drmgr/lsslot.c
@@ -33,7 +33,7 @@
 
 #include "options.c"
 
-int output_level = 0;
+unsigned output_level = 0;
 int log_fd = 0;
 
 int read_dynamic_memory_v2 = 1;
@@ -435,7 +435,7 @@ static void parse_options(int argc, char *argv[])
 			break;
 
 		    case 'd':
-			set_output_level(atoi(optarg));
+			set_output_level(strtoul(optarg, NULL, 10));
 			break;
 
 		    case 'F':

--- a/src/drmgr/ofdt.h
+++ b/src/drmgr/ofdt.h
@@ -182,8 +182,8 @@ int get_drc_by_index(uint32_t, struct dr_connector *, char *, char *);
 
 int get_min_common_depth(void);
 int get_assoc_arrays(const char *dir, struct assoc_arrays *aa,
-		     int min_common_depth);
-int of_associativity_to_node(const char *dir, int min_common_depth);
+		     unsigned min_common_depth);
+int of_associativity_to_node(const char *dir, unsigned min_common_depth);
 int init_node(struct dr_node *);
 
 static inline int aa_index_to_node(struct assoc_arrays *aa, uint32_t aa_index)

--- a/src/drmgr/options.c
+++ b/src/drmgr/options.c
@@ -45,7 +45,7 @@ int usr_prompt = 1;
 
 /* user-specified quantity of devices to add/remove */
 /* user-specified quantity of accelerator QoS credits to assign */
-int usr_drc_count = 0;
+unsigned usr_drc_count = 0;
 
 /* user specified drc type to use */
 enum drc_type usr_drc_type = DRC_TYPE_NONE;

--- a/src/lparstat.c
+++ b/src/lparstat.c
@@ -139,7 +139,7 @@ static int assign_cpu_sysfs_fds(int threads_in_system)
 	char sysfs_file_path[SYSFS_PATH_MAX];
 
 	cpu_sysfs_fds =
-		(cpu_sysfs_fd*)calloc(sizeof(cpu_sysfs_fd), threads_in_system);
+		(cpu_sysfs_fd*)calloc(threads_in_system, sizeof(cpu_sysfs_fd));
 	if (!cpu_sysfs_fds) {
 		fprintf(stderr, "Failed to allocate memory for sysfs file descriptors\n");
 		return -1;

--- a/src/nvram.c
+++ b/src/nvram.c
@@ -670,7 +670,7 @@ getsmallvalue(char *p, char *buf)
 static char *
 lookupfield(char *p)
 {
-    int i;
+    unsigned i;
 
     for (i = 0; (i < sizeof(descs) / sizeof(descs[0])); i++) {
 	if (strcmp(p, descs[i].name) == 0)
@@ -1183,7 +1183,7 @@ print_of_config_part(struct nvram *nvram, char *pname)
 {
     struct partition_header	*phead;
     char	*data;
-    int		i;
+    unsigned	i;
 
     phead = nvram_find_partition(nvram, 0, pname, NULL);
     if (phead == NULL) 
@@ -1225,7 +1225,8 @@ print_of_config(struct nvram *nvram, char *config_var, char *pname,
 {
     struct partition_header *phead;
     char *data, terminator;
-    int  i, varlen;
+    int  i;
+    size_t varlen;
     int  rc = -1;
 
     terminator = '\n';

--- a/src/ppc64_cpu.c
+++ b/src/ppc64_cpu.c
@@ -854,7 +854,7 @@ static void report_system_power_mode(void)
 static void setrlimit_open_files(void)
 {
 	struct rlimit old_rlim, new_rlim;
-	int new = threads_in_system + 8;
+	unsigned new = threads_in_system + 8;
 
 	getrlimit(RLIMIT_NOFILE, &old_rlim);
 

--- a/src/rtas_dbg.c
+++ b/src/rtas_dbg.c
@@ -182,7 +182,7 @@ struct rtas_token *get_rtas_token_by_name(char *name,
 	return NULL;
 }
 
-struct rtas_token *get_rtas_token_by_value(int value,
+struct rtas_token *get_rtas_token_by_value(unsigned value,
 					   struct rtas_token *tok_list)
 {
 	struct rtas_token *tok;
@@ -269,7 +269,7 @@ int main(int argc, char *argv[])
 	}
 
 	if ((dbg_arg[0] >= '0') && (dbg_arg[0] <= '9'))
-		tok = get_rtas_token_by_value(strtol(dbg_arg, NULL, 0),
+		tok = get_rtas_token_by_value(strtoul(dbg_arg, NULL, 0),
 					      tok_list);
 	else
 		tok = get_rtas_token_by_name(dbg_arg, tok_list);

--- a/src/uesensor.c
+++ b/src/uesensor.c
@@ -422,6 +422,8 @@ main (int argc, char **argv)
 	}
 
 	if (text || numerical) {
+		unsigned i;
+
 		/* Print the status/value of all sensors */
 		fd = open(PATH_RTAS_SENSORS, O_RDONLY);
 


### PR DESCRIPTION
The bulk of the warnings is signed vs unsigned comparison.

While this is dodgy because there is no clear semantic for such comparison the warning is not all that helpful in itself.

A value can be automatically promoted between signed and unsigned when passed as function argument, for example.