### PR TITLE
ppc64_cpu: Fix handling of non-contiguous CPU IDs 

### DIFF
--- a/src/common/cpu_info_helpers.c
+++ b/src/common/cpu_info_helpers.c
@@ -203,6 +203,113 @@ int __get_one_smt_state(int core, int threads_per_cpu)
 	return smt_state;
 }
 
+int get_present_cpu_count(void)
+{
+        int start, end, total_cpus = 0;
+        size_t len = 0;
+        char *line = NULL;
+        FILE *fp;
+        char *token;
+
+        fp = fopen(CPU_PRESENT_PATH, "r");
+        if (!fp) {
+                perror("Error opening CPU_PRESENT_PATH");
+                return -1;
+        }
+
+        if (getline(&line, &len, fp) == -1) {
+                perror("Error reading CPU_PRESENT_PATH");
+                fclose(fp);
+                free(line);
+                return -1;
+        }
+        fclose(fp);
+
+        token = strtok(line, ",");
+        while (token) {
+                if (sscanf(token, "%d-%d", &start, &end) == 2) {
+                        total_cpus += (end - start + 1);
+                } else if (sscanf(token, "%d", &start) == 1) {
+                        total_cpus++;
+                }
+                token = strtok(NULL, ",");
+        }
+
+        free(line);
+        return total_cpus;
+}
+
+int get_present_core_list(int **present_cores, int *num_present_cores, int threads_per_cpu)
+{
+        FILE *fp = NULL;
+        char *line = NULL;
+        char *token = NULL;
+        size_t len = 0;
+        ssize_t read;
+        int core_count = 0;
+        int core_list_size;
+        int *cores = NULL;
+        int start, end, i;
+
+        if (threads_per_cpu <= 0) {
+                fprintf(stderr, "Invalid threads_per_cpu value, got %d expected >= 1\n", threads_per_cpu);
+                return -1;
+        }
+
+        core_list_size = get_present_cpu_count() / threads_per_cpu;
+        if (core_list_size <= 0) {
+                fprintf(stderr, "Error while calculating core list size\n");
+                return -1;
+        }
+
+        cores = malloc(core_list_size * sizeof(int));
+        if (!cores) {
+                perror("Memory allocation failed");
+                goto cleanup;
+        }
+
+        fp = fopen(CPU_PRESENT_PATH, "r");
+        if (!fp) {
+                perror("Error opening file");
+                goto cleanup;
+        }
+
+        read = getline(&line, &len, fp);
+        if (read == -1) {
+                perror("Error reading file");
+                goto cleanup;
+        }
+
+        token = strtok(line, ",");
+        while (token) {
+                if (sscanf(token, "%d-%d", &start, &end) == 2) {
+                        for (i = start; i <= end; i++) {
+                                if (i % threads_per_cpu == 0) {
+                                        cores[core_count++] = i / threads_per_cpu;
+                                }
+                        }
+                } else if (sscanf(token, "%d", &start) == 1) {
+                        if (start % threads_per_cpu == 0) {
+                                cores[core_count++] = start / threads_per_cpu;
+                        }
+                }
+                token = strtok(NULL, ",");
+        }
+
+        *present_cores = cores;
+        *num_present_cores = core_count;
+        free(line);
+        return 0;
+
+cleanup:
+        if (fp) {
+                fclose(fp);
+        }
+        free(line);
+        free(cores);
+        return -1;
+}
+
 static void print_cpu_list(const cpu_set_t *cpuset, int cpuset_size,
 		           int cpus_in_system)
 {

--- a/src/common/cpu_info_helpers.h
+++ b/src/common/cpu_info_helpers.h
@@ -24,9 +24,10 @@
 #ifndef _CPU_INFO_HELPERS_H
 #define _CPU_INFO_HELPERS_H
 
-#define SYSFS_CPUDIR    "/sys/devices/system/cpu/cpu%d"
-#define SYSFS_SUBCORES  "/sys/devices/system/cpu/subcores_per_core"
-#define INTSERV_PATH    "/proc/device-tree/cpus/%s/ibm,ppc-interrupt-server#s"
+#define SYSFS_CPUDIR      "/sys/devices/system/cpu/cpu%d"
+#define SYSFS_SUBCORES    "/sys/devices/system/cpu/subcores_per_core"
+#define INTSERV_PATH      "/proc/device-tree/cpus/%s/ibm,ppc-interrupt-server#s"
+#define CPU_PRESENT_PATH  "/sys/devices/system/cpu/present"
 
 #define SYSFS_PATH_MAX	128
 
@@ -39,6 +40,8 @@ extern int num_subcores(void);
 extern int get_attribute(char *path, const char *fmt, int *value);
 extern int get_cpu_info(int *threads_per_cpu, int *cpus_in_system,
 			int *threads_in_system);
+extern int get_present_core_list(int **present_cores, int *num_present_cores,
+			int threads_per_cpu);
 extern int __is_smt_capable(int threads_in_system);
 extern int __get_one_smt_state(int core, int threads_per_cpu);
 extern int __do_smt(bool numeric, int cpus_in_system, int threads_per_cpu,


### PR DESCRIPTION
```
In ppc64le environments, adding or removing CPUs dynamically through
DLPAR can create gaps in CPU IDs, such as `0-103,120-151`, in this
case CPUs 104-119 are missing.

ppc64_cpu doesn't handles this scenario and always considers CPU IDs
to be contiguous causing issues in core numbering, cpu info and SMT
mode reporting.

To illustrate the issues this patch fixes, consider the following
system configuration:

$ lscpu
Architecture:             ppc64le
Byte Order:               Little Endian
CPU(s):                   136
On-line CPU(s) list:      0-103,120-151

**Note: CPU IDs are non-contiguous**

-----------------------------------------------------------------
Before Patch:
-----------------------------------------------------------------

$ ppc64_cpu --info
Core   0:    0*    1*    2*    3*    4*    5*    6*    7*
Core   1:    8*    9*   10*   11*   12*   13*   14*   15*
Core   2:   16*   17*   18*   19*   20*   21*   22*   23*
Core   3:   24*   25*   26*   27*   28*   29*   30*   31*
Core   4:   32*   33*   34*   35*   36*   37*   38*   39*
Core   5:   40*   41*   42*   43*   44*   45*   46*   47*
Core   6:   48*   49*   50*   51*   52*   53*   54*   55*
Core   7:   56*   57*   58*   59*   60*   61*   62*   63*
Core   8:   64*   65*   66*   67*   68*   69*   70*   71*
Core   9:   72*   73*   74*   75*   76*   77*   78*   79*
Core  10:   80*   81*   82*   83*   84*   85*   86*   87*
Core  11:   88*   89*   90*   91*   92*   93*   94*   95*
Core  12:   96*   97*   98*   99*  100*  101*  102*  103*
........................................................... *gap*
Core  13:  120*  121*  122*  123*  124*  125*  126*  127*
Core  14:  128*  129*  130*  131*  132*  133*  134*  135*
Core  15:  136*  137*  138*  139*  140*  141*  142*  143*
Core  16:  144*  145*  146*  147*  148*  149*  150*  151*

**Although the CPU IDs are non contiguous, associated core IDs are
represented in contiguous order, which makes it harder to interpret
this clearly.**

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

$ ppc64_cpu --cores-on
Number of cores online = 15

**Expected: Number of online cores = 17**
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

$ ppc64_cpu --offline-cores
Cores offline = 13, 14

**Even though no cores are actually offline, two cores (13, 14)
are displayed as offline.**
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

$ ppc64_cpu --online-cores
Cores online = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16

**The list of online cores is missing two cores (13, 14).**
-----------------------------------------------------------------

To resolve this, use the present CPU list from sysfs to assign
numbers to CPUs and cores, which will make this accurate.

$ cat /sys/devices/system/cpu/present
0-103,120-151

With this patch, the command output correctly reflects the
current CPU configuration, providing a more precise representation
of the system state.

-----------------------------------------------------------------
After Patch:
-----------------------------------------------------------------

$ ppc64_cpu --info
Core   0:    0*    1*    2*    3*    4*    5*    6*    7*
Core   1:    8*    9*   10*   11*   12*   13*   14*   15*
Core   2:   16*   17*   18*   19*   20*   21*   22*   23*
Core   3:   24*   25*   26*   27*   28*   29*   30*   31*
Core   4:   32*   33*   34*   35*   36*   37*   38*   39*
Core   5:   40*   41*   42*   43*   44*   45*   46*   47*
Core   6:   48*   49*   50*   51*   52*   53*   54*   55*
Core   7:   56*   57*   58*   59*   60*   61*   62*   63*
Core   8:   64*   65*   66*   67*   68*   69*   70*   71*
Core   9:   72*   73*   74*   75*   76*   77*   78*   79*
Core  10:   80*   81*   82*   83*   84*   85*   86*   87*
Core  11:   88*   89*   90*   91*   92*   93*   94*   95*
Core  12:   96*   97*   98*   99*  100*  101*  102*  103*
........................................................... *gap*
Core  15:  120*  121*  122*  123*  124*  125*  126*  127*
Core  16:  128*  129*  130*  131*  132*  133*  134*  135*
Core  17:  136*  137*  138*  139*  140*  141*  142*  143*
Core  18:  144*  145*  146*  147*  148*  149*  150*  151*

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

$ ppc64_cpu --cores-on
Number of cores online = 17

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

$ ppc64_cpu --offline-cores
Cores offline =

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

$ ppc64_cpu --online-cores
Cores online = 0,1,2,3,4,5,6,7,8,9,10,11,12,15,16,17,18

-----------------------------------------------------------------

Signed-off-by: Aboorva Devarajan <aboorvad@linux.ibm.com>

```