### PR TITLE
fix in nvram definition

### DIFF
--- a/src/nvram.c
+++ b/src/nvram.c
@@ -903,9 +903,9 @@ dump_rtas_event_entry(char *data, int len)
 {
     void *rtas_event;
     void *handle;
-    void *(*parse_rtas_event)();
-    void (*rtas_print_event)();
-    void (*cleanup_rtas_event)();
+    void *(*parse_rtas_event)(char*, int);
+    void (*rtas_print_event)(FILE *, struct rtas_event *, int);
+    void (*cleanup_rtas_event)(struct rtas_event *);
 
     handle = dlopen("/usr/lib/librtasevent.so", RTLD_LAZY);
     if (handle == NULL)


### PR DESCRIPTION
Fix errors related to nvram functions in src/nvram.c while building the powerpc-utils package in Fedora (Mentioned below), this is due to old C syntax present in **powerpc-utls** package code base. 
Fixing definition of regressed functions are able to solve the issue.

Issue that I was getting: 

```
src/nvram.c: In function ‘dump_rtas_event_entry’:
src/nvram.c:932:18: error: too many arguments to function ‘parse_rtas_event’; expected 0, have 2
  932 |     rtas_event = parse_rtas_event(data, len);
      |                  ^~~~~~~~~~~~~~~~ ~~~~
src/nvram.c:938:5: error: too many arguments to function ‘rtas_print_event’; expected 0, have 3
  938 |     rtas_print_event(stdout, rtas_event, 0);
      |     ^~~~~~~~~~~~~~~~ ~~~~~~
src/nvram.c:940:5: error: too many arguments to function ‘cleanup_rtas_event’; expected 0, have 1
  940 |     cleanup_rtas_event(rtas_event);
      |     ^~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
In file included from src/vcpustat.c:34:
./src/common/pseries_platform.h:21: warning: header guard ‘PLATFORM_H’ followed by ‘#define’ of a different macro [-Wheader-guard]
   21 | #ifndef PLATFORM_H
./src/common/pseries_platform.h:22: note: ‘PLARFORM_H’ is defined here; did you mean ‘PLATFORM_H’?
   22 | #define PLARFORM_H
make: *** [Makefile:1085: src/nvram.o] Error 1
make: *** Waiting for unfinished jobs....
In file included from src/activate_fw.c:70:
./src/common/pseries_platform.h:21: warning: header guard ‘PLATFORM_H’ followed by ‘#define’ of a different macro [-Wheader-guard]
   21 | #ifndef PLATFORM_H
./src/common/pseries_platform.h:22: note: ‘PLARFORM_H’ is defined here; did you mean ‘PLATFORM_H’?
   22 | #define PLARFORM_H
RPM build errors:
error: Bad exit status from /var/tmp/rpm-tmp.hpdalO (%build)
```