### PR TITLE
hcn-init: Make usable in initrd

### DIFF
--- a/systemd/hcn-init.service.in.in
+++ b/systemd/hcn-init.service.in.in
@@ -3,6 +3,7 @@ Description=hybrid virtual network scan and config for @CM@
 After=@CM@.service
 Requisite=@CM@.service
 PartOf=@CM@.service
+DefaultDependencies=no
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
DefaultDependencies=no is required to include a service in an initrd.