### PR TITLE
nvram: Add argument types to dlsym'd librtasevent functions

### DIFF
--- a/src/nvram.c
+++ b/src/nvram.c
@@ -901,11 +901,11 @@ dump_errlog(struct nvram *nvram)
 int
 dump_rtas_event_entry(char *data, int len)
 {
-    void *rtas_event;
+    struct rtas_event *rtas_event;
     void *handle;
-    void *(*parse_rtas_event)();
-    void (*rtas_print_event)();
-    void (*cleanup_rtas_event)();
+    struct rtas_event *(*parse_rtas_event)(char *, int);
+    int (*rtas_print_event)(FILE *, struct rtas_event *, int);
+    int (*cleanup_rtas_event)(struct rtas_event *);
 
     handle = dlopen("/usr/lib/librtasevent.so", RTLD_LAZY);
     if (handle == NULL)


### PR DESCRIPTION
With GCC 15 (which assumes C23 by default), an empty argument list is interpreted as zero arguments rather than an arbitrary number of arguments.

Signatures are based on:

  https://github.com/ibm-power-utilities/librtas/blob/v2.0.6/librtasevent_src/librtasevent.h