### PR TITLE
ppc64_cpu: check opendir() return value before calling readdir()

### DIFF
--- a/src/ppc64_cpu.c
+++ b/src/ppc64_cpu.c
@@ -887,6 +887,8 @@ static int report_platform_energy_freq_mode(struct energy_freq_info *eq)
 	if (stat(path, &s) || !S_ISDIR(s.st_mode))
 		return -1;
 	dirp = opendir(path);
+	if (!dirp)
+		return -1;
 
 	while ((entry = readdir(dirp)) != NULL) {
 		char val_buf[64], file_name[64];


### PR DESCRIPTION
## Summary

`opendir()` can return `NULL` if the directory cannot be opened. In `report_platform_energy_freq_mode()`, the return value of `opendir(path)` was used directly as the argument to `readdir()`, which carries a `nonnull` attribute on its parameter. Passing `NULL` here is undefined behaviour and is flagged by the static analyser.

## Fix

Add an explicit `NULL` check on `dirp` immediately after the `opendir()` call and return `-1` on failure — consistent with the existing error-return pattern throughout this function.

## Affected file
- `src/ppc64_cpu.c` — `report_platform_energy_freq_mode()`, line 891

## Bug category
Argument with nonnull attribute passed null (API checker)

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>