### PR TITLE
vcpustat: fix memory leak in process_stats 

### DIFF
--- a/src/vcpustat.c
+++ b/src/vcpustat.c
@@ -215,6 +215,8 @@ void process_stats(int interval, int count)
 
 	if (!stats1 || !stats2) {
 		fprintf(stderr, "Error allocating memory for stats\n");
+		free(stats1);
+		free(stats2);
 		return;
 	}
 


### PR DESCRIPTION
## Summary

Fixed a memory leak in the `process_stats()` function in `vcpustat.c`.

## Issue

If either `stats1` or `stats2` allocation fails at line 217, the function returns without freeing the successfully allocated pointer, causing a memory leak.

## Fix

Add missing `free(stats1)` and `free(stats2)` calls in the error path before the return statement.

## Affected file
- `src/vcpustat.c` — `process_stats()`, line 217

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>