### PR TITLE
ppc64_cpu: fix memory leak in do_online_cores 

### DIFF
--- a/src/ppc64_cpu.c
+++ b/src/ppc64_cpu.c
@@ -1152,6 +1152,7 @@ static int do_online_cores(char *cores, int state)
 		printf("Bad or inconsistent SMT state: use ppc64_cpu --smt=on|off to set all\n"
 				"cores to have the same number of online threads to continue.\n");
 		do_info();
+		free(core_state);
 		free(present_cores);
 		return -1;
 	}


### PR DESCRIPTION
Memory leak when smt_state validation fails. The core_state pointer is allocated but not freed before returning in the error case.

Added free(core_state) before the existing free(present_cores) in the smt_state == -1 error path to ensure all allocations are properly cleaned up.

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>