### PR TITLE
nvram: remove dead assignment in update_of_config_var 

### DIFF
--- a/src/nvram.c
+++ b/src/nvram.c
@@ -1424,7 +1424,7 @@ update_of_config_var(struct nvram *nvram, char *config_var, char *pname)
     }
     
     /* write the partition out to nvram */
-    for (rc = 0, len = 0; len < part_size; len += rc) {
+    for (len = 0; len < part_size; len += rc) {
 	rc = write(nvram->fd, new_part + len, part_size - len);
 	if (rc <= 0)
 	    break;


### PR DESCRIPTION
Removed unused rc = 0 initialization in the for loop. The rc variable is reassigned immediately by write() on the next line, making the initial assignment dead code.

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>