### PR TITLE
lparstat: remove dead increment in print_system_configuration 

### DIFF
--- a/src/lparstat.c
+++ b/src/lparstat.c
@@ -1126,7 +1126,7 @@ void print_system_configuration(void)
 		offset += sprintf(buf + offset, "cpus=%s ", value);
 	}
 	get_sysdata("DesEntCap", &descr, value);
-	offset += sprintf(buf + offset, "ent=%s ", value);
+	sprintf(buf + offset, "ent=%s ", value);
 
 	fprintf(stdout, "\nSystem Configuration\n%s\n\n", buf);
 }


### PR DESCRIPTION
Removed unused offset += from the last sprintf call. The offset variable is used to track buffer position, but after the final sprintf call, the offset value is never used again.

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>