### PR TITLE
lparstat: remove dead initialization in get_processor_type 

### DIFF
--- a/src/lparstat.c
+++ b/src/lparstat.c
@@ -727,7 +727,7 @@ int parse_proc_stat()
 
 void get_processor_type(struct sysentry *se, char *buf)
 {
-	char *value = "?";
+	char *value;
 
 	if (se->value[0] == '1')
 		value = "Shared";


### PR DESCRIPTION
Removed unused initialization of value variable. The value pointer is always assigned in the if/else block before use, making the initial assignment dead code.

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>