### PR TITLE
cpu_info_helpers: initialize physical_id to avoid garbage return 

### DIFF
--- a/src/common/cpu_info_helpers.c
+++ b/src/common/cpu_info_helpers.c
@@ -86,7 +86,7 @@ int __sysattr_is_writeable(char *attribute, int threads_in_system)
 int cpu_physical_id(int thread)
 {
 	char path[SYSFS_PATH_MAX];
-	int rc, physical_id;
+	int rc, physical_id = 0;
 
 	sprintf(path, SYSFS_CPUDIR"/physical_id", thread);
 	rc = get_attribute(path, "%d", &physical_id);


### PR DESCRIPTION
Initialize physical_id variable to 0 to prevent returning garbage value if get_attribute() fails. The variable is returned but was never initialized, leading to undefined behavior.

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>