### PR TITLE
lsprop: check stream state before reading in loop

### DIFF
--- a/src/lsprop.c
+++ b/src/lsprop.c
@@ -249,9 +249,11 @@ void lsprop(FILE *f, char *name)
     }
     printf("\n");
     if (n == maxbytes) {
+	if (!ferror(f)) {
 	while ((i = fread(buf, 1, maxbytes, f)) > 0)
 	    n += i;
 	if (n > maxbytes)
 	    printf("\t\t [%d bytes total]\n", n);
-    }
+    	}
+	}
 }


### PR DESCRIPTION
Add ferror() check before the fread() loop to prevent reading from an invalid stream state. The file stream may be in an error state after the initial read, so we must verify it before attempting further reads.

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>