### PR TITLE
ppc64_cpu: close directory on error in report_platform_energy_freq_mode

### DIFF
--- a/src/ppc64_cpu.c
+++ b/src/ppc64_cpu.c
@@ -901,8 +901,10 @@ static int report_platform_energy_freq_mode(struct energy_freq_info *eq)
 
 		sprintf(file_name, "%s/%d/value", path, id);
 		f = fopen(file_name, "r");
-		if (!f)
+		if (!f) {
+			closedir(dirp);
 			return -1;
+		}
 		if (fgets(val_buf, 64, f) == NULL)
 			return -1;
 		fclose(f);
@@ -911,8 +913,10 @@ static int report_platform_energy_freq_mode(struct energy_freq_info *eq)
 		if (has_str_val(id)) {
 			sprintf(file_name, "%s/%d/value_desc", path, id);
 			f = fopen(file_name, "r");
-			if (!f || fgets(val_buf, 64, f) == NULL)
+			if (!f || fgets(val_buf, 64, f) == NULL) {
+				closedir(dirp);
 				return -1;
+			}
 			fclose(f);
 		}
 


### PR DESCRIPTION
Add closedir(dirp) before returning on errors when fopen() or fgets() fail. The directory descriptor was opened but not closed on early returns, causing a resource leak.

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>