### PR TITLE
cpu_info_helpers: close file descriptor on success in get_present_core_list

### DIFF
--- a/src/common/cpu_info_helpers.c
+++ b/src/common/cpu_info_helpers.c
@@ -298,6 +298,7 @@ int get_present_core_list(int **present_cores, int *num_present_cores, int threa
 
         *present_cores = cores;
         *num_present_cores = core_count;
+	fclose(fp);
         free(line);
         return 0;
 


### PR DESCRIPTION
The file descriptor fp was opened but never closed on the successful return path. Only the error path via goto cleanup closed it.

Added fclose(fp) before the successful return to ensure the file descriptor is always closed.

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>