### PR TITLE
lsprop: guard fread loop against error and EOF stream state

### DIFF
--- a/src/lsprop.c
+++ b/src/lsprop.c
@@ -249,8 +249,10 @@ void lsprop(FILE *f, char *name)
     }
     printf("\n");
     if (n == maxbytes) {
-	while ((i = fread(buf, 1, maxbytes, f)) > 0)
-	    n += i;
+	if (!ferror(f) && !feof(f)) {
+		while ((i = fread(buf, 1, maxbytes, f)) > 0)
+		    n += i;
+	}
 	if (n > maxbytes)
 	    printf("\t\t [%d bytes total]\n", n);
     }


### PR DESCRIPTION
Prevent reading from a stream that is already in an error or EOF state. The initial fread() leaves the stream at EOF or in an error state. The subsequent fread() loop ran without checking, causing an invalid stream state access.

Added !ferror(f) && !feof(f) guard before the secondary fread loop.

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>