### PR TITLE
ppc64_cpu: guard against zero-size allocation in do_cores_on

### DIFF
--- a/src/ppc64_cpu.c
+++ b/src/ppc64_cpu.c
@@ -1248,6 +1248,9 @@ static int do_cores_on(char *state)
 		}
 	}
 
+	if (cpus_in_system <= 0)
+		return -EINVAL;
+
 	core_state = calloc(cpus_in_system, sizeof(int));
 	if (!core_state)
 		return -ENOMEM;


### PR DESCRIPTION
If cpus_in_system is 0, calloc(0, ...) returns a valid non-NULL pointer but subsequent array accesses are undefined behaviour. Added an early return with -EINVAL if cpus_in_system is not positive before the calloc.

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>