### PR TITLE
ppc64_cpu: initialize errno before syscall in set_one_smt_state

### DIFF
--- a/src/ppc64_cpu.c
+++ b/src/ppc64_cpu.c
@@ -299,6 +299,7 @@ static int set_one_smt_state(int thread, int online_threads)
 	for (i = 0; i < threads_per_cpu; i++) {
 		snprintf(path, SYSFS_PATH_MAX, SYSFS_CPUDIR"/%s", thread + i,
 			 "online");
+		errno = 0;
 		if (i < online_threads)
 			rc = online_thread(path);
 		else


### PR DESCRIPTION
errno may be undefined when checked after online_thread() or offline_thread() if those functions return -1 without setting errno. Initialize errno to 0 before the calls to ensure a defined value when the EINVAL check runs.

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>