### PR TITLE
ppc64_cpu: initialize errno before syscall in set_smt_control

### DIFF
--- a/src/ppc64_cpu.c
+++ b/src/ppc64_cpu.c
@@ -394,6 +394,7 @@ static int is_dscr_capable(void)
  */
 static int set_smt_control(int smt_state)
 {
+	errno = 0;
 	if (set_attribute(SYS_SMT_CONTROL, "%d", smt_state)) {
 		switch (errno) {
 			case ENOENT:


### PR DESCRIPTION
errno may be undefined when checked in the switch after set_attribute() if it returns non-zero without setting errno. Initialize errno to 0 before the call to ensure a defined value when the switch runs.

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>