### PR TITLE
cpu_info_helpers: initialize errno before get_attribute in cpu_online

### DIFF
--- a/src/common/cpu_info_helpers.c
+++ b/src/common/cpu_info_helpers.c
@@ -103,6 +103,7 @@ int cpu_online(int thread)
 	int rc, online;
 
 	sprintf(path, SYSFS_CPUDIR"/online", thread);
+	errno = 0;
 	rc = get_attribute(path, "%d", &online);
 
 	/* This attribute does not exist in kernels without hotplug enabled */


### PR DESCRIPTION
errno may be undefined when checked after get_attribute() if it returns non-zero without setting errno. Initialize errno to 0 before the call to ensure a defined value when the ENOENT check runs.

Signed-off-by: Fahim Hassan <fahim.hassan@ibm.com>